### PR TITLE
Update agent-std-cluster.md

### DIFF
--- a/agent/agent-std-cluster.md
+++ b/agent/agent-std-cluster.md
@@ -256,7 +256,7 @@ Complete the following steps:
 
 You can add additional metadata fields to the routed logs.
 
-1. Edit the `logger-agent-config.yaml` file in the `logger-agent` namespace.
+1. Edit the `logger-agent-config.yaml` file or configmap in the ``ibm-observe namespace.
 
 2. In the `fluent-bit.conf` section add your custom metadata using this structure.
 
@@ -287,7 +287,7 @@ You can add additional metadata fields to the routed logs.
 4. Restart the daemon set to apply the changes by running the following:
 
    ```sh
-   kubectl rollout restart daemonset logger-agent-ds -n logger-agent
+   kubectl rollout restart daemonset logger-agent-ds -n ibm-observe
    ```
    {: codeblock}
 


### PR DESCRIPTION
Fix namespace references to ibm-observe

Thanks for taking the time to contribute to the IBM Cloud docs! After you open your pull request, a maintainer should review it soon.

We don't merge changes directly in this repository because content is not published from here. However, we'll incorporate any changes in our upstream repository so that they're reflected in the docs.

### Description

Fix namespace references to ibm-observe. Previously wrong namespace logger-agent

###  Any other comments?

Also specify configmap

---

### For reviewers (This section is only for IBMers)

You can't merge pull requests here.

- If you can incorporate these changes, copy them to your GitHub Enterprise repo. Leave a comment and close the pull request.
- If you can't accept the changes, leave information about why, and close the pull request.

If you don't have permission to close the request, ask for help in the IBM Cloud \#docs Slack channel.
